### PR TITLE
QNA Shortcuts

### DIFF
--- a/src/clojurians_log/slack/socket.clj
+++ b/src/clojurians_log/slack/socket.clj
@@ -11,8 +11,11 @@
   (:import
    (com.slack.api.bolt App AppConfig)
    (com.slack.api.bolt.handler BoltEventHandler)
+   (com.slack.api.bolt.handler.builtin MessageShortcutHandler)
    (com.slack.api.bolt.socket_mode SocketModeApp)
-   (com.slack.api.model.event ChannelCreatedEvent ChannelRenameEvent MessageChangedEvent MessageChannelJoinEvent MessageDeletedEvent MessageEvent MessageRepliedEvent ReactionAddedEvent ReactionRemovedEvent)))
+   (com.slack.api.model.event ChannelCreatedEvent ChannelRenameEvent
+                              MessageChangedEvent MessageChannelJoinEvent MessageDeletedEvent MessageEvent
+                              MessageRepliedEvent ReactionAddedEvent ReactionRemovedEvent)))
 
 (set! *warn-on-reflection* true)
 
@@ -23,6 +26,13 @@
   (let [event (cske/transform-keys csk/->kebab-case-keyword event)]
     (prn event))
   (println "-------"))
+
+(defn create-qna-handler []
+  (reify MessageShortcutHandler
+    (apply [_ payload ctx]
+      (let [event (jd/from-java-deep (.getPayload payload) {})]
+        (println event))
+      (.ack ctx))))
 
 (defn create-handler
   "Create a handler with dispatch-evt"
@@ -56,6 +66,7 @@
               (.event ChannelRenameEvent handler)
               (.event ChannelCreatedEvent handler)
               (.event ReactionAddedEvent handler)
+              (.messageShortcut "qna" (create-qna-handler))
               (.event ReactionRemovedEvent handler))]
     (doto (SocketModeApp. ^String slack-app-token app)
       (.startAsync))))
@@ -75,9 +86,9 @@
      :tx-log (create-event-tx-logger config event-ch)
      :event-ch event-ch}))
 
-(defmethod ig/halt-key! ::app [_ {:keys [^SocketModeApp socket-app event-ch]}]
+(defmethod ig/halt-key! ::app [_ {:keys [^SocketModeApp socket event-ch]}]
   ;; (log/info :socket-app/stoping :now)
-  (.stop ^SocketModeApp socket-app)
+  (.stop ^SocketModeApp socket)
   (async/close! event-ch))
 
 (comment


### PR DESCRIPTION
Saving threads for future use "separately" from the chronological logs is something which I've always wanted to do. This PR is a step forward in that direction.

The idea is to add a slack "shortcut" option to every slack message which will allow that particular thread to be converted into a "QNA" page on clojurians slack archive.

This is how the shortcut option looks:

![image](https://user-images.githubusercontent.com/4194289/168901331-6e3a85a7-996e-4e47-8180-32af5df15b6c.png)

Once someone tags a thread as a QNA using the shortcut, a new entry will be added on a special "QNA" page on clojurians archive.

These will have a permalink + searchable + provide google SEO + possibly in the future can be ranked up/down/sorted/ordered/etc